### PR TITLE
Adding index.html to build-release.cmd to fix deployment issues.

### DIFF
--- a/build-release.cmd
+++ b/build-release.cmd
@@ -1,1 +1,1 @@
-"%ProgramFiles%\7-Zip\7z.exe" a -tzip releases\retro-b5500-%1.zip build-release.cmd emulator\ webui\ -x!webui\prototypes\* tools\*.html tools\*.js tools\*.card
+"%ProgramFiles%\7-Zip\7z.exe" a -tzip releases\retro-b5500-%1.zip build-release.cmd index.html emulator\ webui\ -x!webui\prototypes\* tools\*.html tools\*.js tools\*.card


### PR DESCRIPTION
With change, unpacking the resulting zip file to B5500 folder under tomcat's webapp folder allows get request to http://localhost:8080/B5500 to succeed.
